### PR TITLE
Add check_restricted_files WF

### DIFF
--- a/.github/workflows/check-restricted-files.yml
+++ b/.github/workflows/check-restricted-files.yml
@@ -1,0 +1,50 @@
+name: Check Restricted Files
+
+on:
+  pull_request:
+    paths:
+      - '**/*'
+
+jobs:
+  check_restricted_files:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Fetch all branches
+        run: git fetch --all
+
+      - name: List all changed files
+        id: changed-files
+        run: |
+          git diff --name-only origin/main > changed_files.txt  || echo "No differences found."
+          cat changed_files.txt
+
+      - name: Check for unauthorized file changes
+        run: |
+          ALLOWED_FILES=(
+            "sync-fork.yml"
+            "check-restricted-files.yml"
+          )
+
+          unauthorized_files=""
+
+          # Loop through each changed file
+          while IFS= read -r file; do
+            # Extract the file name from the path
+            filename=$(basename "$file")
+
+            # Check if the filename is in the allowed files list
+            if ! printf "%s\n" "${ALLOWED_FILES[@]}" | grep -qx "$filename"; then
+              unauthorized_files+="$file"$'\n'
+            fi
+          done < changed_files.txt
+
+          if [[ -n "$unauthorized_files" ]]; then
+            echo "Unauthorized file changes detected:"
+            echo "$unauthorized_files"
+            exit 1
+          else
+            echo "All changed files are authorized."
+          fi

--- a/.github/workflows/check-restricted-files.yml
+++ b/.github/workflows/check-restricted-files.yml
@@ -26,6 +26,14 @@ jobs:
           ALLOWED_FILES=(
             "sync-fork.yml"
             "check-restricted-files.yml"
+            "Dockerfile"
+            ".dockerignore"
+            "staging-build-deploy.yml"
+            "prod-build-deploy.yml"
+            "values_api.yml"
+            "values_frontend.yml"
+            "action.yml"
+            ".gitattributes"
           )
 
           unauthorized_files=""


### PR DESCRIPTION
Added a github workflow to check if any restricted files have been changed, that may cause merge conflicts.
The list of files that are allowed to be changed, for this repo, is defined in the workflow itself.

The job runs when a PR is created. If change to any restricted files is detected, than the job with show as failed, on the PR Dashboard. Github send an email to the creator of the PR, stating that the job has failed.