### PR TITLE
TECH-4279 - Update resources

### DIFF
--- a/.github/workflows/prod-build-deploy.yml
+++ b/.github/workflows/prod-build-deploy.yml
@@ -15,7 +15,6 @@ on:
   push:
     branches:
       - deployments/makerdao
-      - TECH-4278-update-resources # Remove this before opening the PR
 
 env:
   APP_NAME: switchboard

--- a/.github/workflows/prod-build-deploy.yml
+++ b/.github/workflows/prod-build-deploy.yml
@@ -15,6 +15,7 @@ on:
   push:
     branches:
       - deployments/makerdao
+      - TECH-4278-update-resources # Remove this before opening the PR
 
 env:
   APP_NAME: switchboard

--- a/deploy/values_frontend.yml
+++ b/deploy/values_frontend.yml
@@ -33,9 +33,9 @@ podAnnotations:
 
 resources:
   limits:
-    memory: 1Gi
+    memory: 128Mi
   requests:
-    cpu: 8m
+    cpu: 30m
     memory: 85Mi
 
 env:

--- a/deploy/values_frontend.yml
+++ b/deploy/values_frontend.yml
@@ -64,5 +64,5 @@ autoscaling:
   enabled: true
   minReplicas: ${AUTOSCALING_MIN_REPLICAS}
   maxReplicas: ${AUTOSCALING_MAX_REPLICAS}
-  targetCPUUtilizationPercentage: 75
-  targetMemoryUtilizationPercentage: 75
+  targetCPUUtilizationPercentage: 85
+  targetMemoryUtilizationPercentage: 85


### PR DESCRIPTION
Previous CPU limit was too low, causing the HPA to max out. Current CPU limit might still be a bit low, but at least we haven't had another alert regarding the HPA maxing out, so it seems OK for now. If needed, it'll probably be best to increase the number of max replicas.