### PR TITLE
TECH-4362 - Increase requested memory for Switchboard's frontend

### DIFF
--- a/deploy/values_frontend.yml
+++ b/deploy/values_frontend.yml
@@ -36,7 +36,7 @@ resources:
     memory: 1Gi
   requests:
     cpu: 30m
-    memory: 85Mi
+    memory: 128Mi
 
 env:
   NEXT_PUBLIC_SWITCHBOARD_GRAPHQL_HOST:


### PR DESCRIPTION
64 to 71Mi is the base memory usage by the pod to just stay alive, which is 75 to 83% percent of the current requested memory and, at 85%, the autoscaler triggers. We should aim to be further away from that 85% since the smallest request to the pods will trigger the HPA to create a new pod (which is what happened recently, maxing out the HPA).

Right now, there are 4 pods for this app and none of them is getting any traffic. They are using ~270Mi for doing nothing, when we could have a single pod using ~70Mi for doing the same thing.