### PR TITLE
TECH-4712 - Update prod's requested memory

### DIFF
--- a/deploy/values_frontend.yml
+++ b/deploy/values_frontend.yml
@@ -36,7 +36,7 @@ resources:
     memory: 1Gi
   requests:
     cpu: 30m
-    memory: 128Mi
+    memory: 168Mi
 
 env:
   NEXT_PUBLIC_SWITCHBOARD_GRAPHQL_HOST:


### PR DESCRIPTION
Due to the low value set for the requested memory, the HPA maxes out without the pods having much/any usage. By increasing the requested memory, the number of idle pods should go down to 2, thus using less than 336Mi while idle (should be ~250Mi, actually, given the current usage per idle pod), instead of the current 355Mi with the maxed out HPA.